### PR TITLE
viewing, caching & retaining hymns & hymnals

### DIFF
--- a/nah/lib/data/db/db_parameters.dart
+++ b/nah/lib/data/db/db_parameters.dart
@@ -11,5 +11,6 @@ const List<String> hymnColumns = [idField, titleField, odField, lyricsField];
 const List<String> hymnalColumns = [idField, titleField, languageField];
 
 const String idType = "INTEGER PRIMARY KEY";
+const String idTypeAutoIncre = "INTEGER PRIMARY KEY AUTOINCREMENT";
 const String textType = "TEXT NOT NULL";
 const String textTypeNullable = "TEXT";

--- a/nah/lib/data/repositories/hymn_repository.dart
+++ b/nah/lib/data/repositories/hymn_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/material.dart';
 import 'package:nah/data/db/database_helper.dart';
 import 'package:nah/data/models/hymn_model.dart';
 import 'package:nah/data/services/nah_services_export.dart';
@@ -21,25 +22,35 @@ class HymnRepository {
   ///
   Future<Result<List<Hymn>>> getHymns(String language) async {
     try {
-      final result = await hymnService.fetchHymns(language);
+      final result = await hymnService.fetchHymns(language.toLowerCase());
       if (result is Success<String>) {
         final List<dynamic> hymnData = json.decode(result.data);
 
         final hymns = [for (final hymn in hymnData) Hymn.fromMap(hymn)];
 
         //cache the hymns to database
-        await databaseHelper.insertHymns(hymns);
+        await databaseHelper.insertHymns(language.toLowerCase(), hymns);
+
         return Success(hymns);
       }
       //if result is an error
       throw Exception((result as Failure).error);
       //catch the error & fall back on the cached hymns
     } catch (e) {
-      final cachedHymns = await databaseHelper.getHymns();
+      //fallback to cached hymns
+      final cachedHymns = await databaseHelper.getHymnsByLanguage(
+        language.toLowerCase(),
+      );
       if (cachedHymns.isNotEmpty) {
         return Success(cachedHymns);
       }
+      debugPrint('Chached hymns fetched');
     }
-    return Failure(Exception('Error: Failed to get hymns from hymn service'));
+    debugPrint('Failed to fetch & load cached hymns');
+    return Failure(
+      Exception(
+        'Error: Failed to get hymns from hymn service and no cached data available',
+      ),
+    );
   }
 }

--- a/nah/lib/domain/app_service.dart
+++ b/nah/lib/domain/app_service.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:nah/data/models/hymn_model.dart';
+import 'package:nah/data/models/hymnal_model.dart';
+import 'package:nah/data/repositories/hymn_repository.dart';
+import 'package:nah/data/services/result.dart';
+
+class AppService {
+  final HymnRepository _hymnRepository;
+  AppService(this._hymnRepository);
+
+  //method to cache all hymns associated with each hymnal fetched
+  Future<void> fetchAndCacheHymnsForAllHymnals(List<Hymnal> hymnalList) async {
+    //iterate through each hymnal & fetch its hymns
+    for (Hymnal hymnal in hymnalList) {
+      final hymnFetchResult = await _hymnRepository.getHymns(
+        hymnal.language.toLowerCase(),
+      );
+      if (hymnFetchResult is Success<List<Hymn>>) {
+        debugPrint('Hymns for ${hymnal.title} cached successfully');
+      } else if (hymnFetchResult is Failure<List<Hymn>>) {
+        debugPrint(
+          'Error in fetching hymns for ${hymnal.title}: ${hymnFetchResult.error.toString()}',
+        );
+      }
+    }
+  }
+}

--- a/nah/lib/main.dart
+++ b/nah/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:nah/data/db/database_helper.dart';
+import 'package:nah/data/repositories/hymn_repository.dart';
 import 'package:nah/data/repositories/hymnal_repository.dart';
-import 'package:nah/data/services/hymnal_service.dart';
+import 'package:nah/data/services/nah_services_export.dart';
+import 'package:nah/domain/app_service.dart';
 import 'package:nah/ui/core/theme/nah_theme.dart';
 import 'package:nah/ui/hymnal/view_model/hymnal_provider.dart';
+import 'package:nah/ui/hymns/view_model/hymn_provider.dart';
 import 'package:nah/ui/hymns/widgets/hymn_screen.dart';
 import 'package:provider/provider.dart';
 
@@ -18,16 +21,23 @@ Future<void> main() async {
       providers: [
         ChangeNotifierProvider(
           create:
+              (context) => HymnalProvider(
+                AppService(HymnRepository(HymnService(), dbHelper)),
+                HymnalRepository(HymnalService(), dbHelper),
+              ),
+        ),
+        ChangeNotifierProvider(
+          create:
               (context) =>
-                  HymnalProvider(HymnalRepository(HymnalService(), dbHelper)),
+                  HymnProvider(HymnRepository(HymnService(), dbHelper)),
         ),
       ],
       child: const MyApp(),
     ),
   );
 
-  //close database resources
-  await closeDatabaseOnAppExit(dbHelper);
+  //close database and release resources
+  // await closeDatabaseOnAppExit(dbHelper);
 }
 
 //method to initalize the app & database

--- a/nah/lib/ui/core/ui/erro_message_with_retry.dart
+++ b/nah/lib/ui/core/ui/erro_message_with_retry.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:nah/ui/hymnal/view_model/hymnal_provider.dart';
+import 'package:nah/ui/hymns/view_model/hymn_provider.dart';
+import 'package:provider/provider.dart';
+
+class ErroMessageWithRetry extends StatelessWidget {
+  const ErroMessageWithRetry({super.key});
+
+  //method to retry loading hymnals & hymns
+  void retryCallBack(BuildContext context) {
+    final hymnalProvider = context.read<HymnalProvider>();
+    hymnalProvider
+      ..loadHymnals()
+      ..selectHymnal(0);
+    context.read<HymnProvider>().loadHymns(
+      hymnalProvider.hymnals.isNotEmpty
+          ? hymnalProvider.hymnals[hymnalProvider.selectedHymnal].language
+              .toLowerCase()
+          : "chichewa",
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Check your internet connection and try again',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 16, color: Colors.white),
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => retryCallBack(context),
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/nah/lib/ui/core/ui/sliver_hymn_list.dart
+++ b/nah/lib/ui/core/ui/sliver_hymn_list.dart
@@ -1,0 +1,72 @@
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+import 'package:nah/data/models/hymn_model.dart';
+import 'package:nah/data/models/hymnal_model.dart';
+
+class SliverHymnList extends StatelessWidget {
+  const SliverHymnList({
+    super.key,
+    required this.hymns,
+    required this.isBookmarked,
+    this.hymnals,
+  });
+  final List<Hymn> hymns;
+  //This variable holds the bool to indicate if the hymn list are bookmarks or not
+  final bool isBookmarked;
+  //if isBookmark, the hymnal list below will be provided, otherwise is nullable
+  //this list is receiving hymnals that can be null themselves due to the selectedHymnal
+  //getter in the hymnal collection provider
+  final List<Hymnal?>? hymnals;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPadding(
+      padding: EdgeInsets.only(top: 8),
+      sliver: SliverList.separated(
+        itemCount: hymns.length,
+        itemBuilder: (context, index) {
+          final hymn = hymns[index];
+          return OpenContainer(
+            closedElevation: 0,
+            closedColor: Theme.of(context).colorScheme.surface,
+            transitionDuration: const Duration(milliseconds: 500),
+            transitionType: ContainerTransitionType.fadeThrough,
+            closedBuilder: (context, action) {
+              return isBookmarked
+                  ? ListTile(
+                    contentPadding: const EdgeInsets.only(left: 16),
+                    title: Text(
+                      '${index + 1}. ${hymn.title}',
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                    subtitle: Padding(
+                      padding: const EdgeInsets.only(left: 20.0),
+                      child: Text(
+                        '${hymnals?[index]?.title ?? "Unknown"}, No: ${hymn.id}',
+                        style: const TextStyle(fontWeight: FontWeight.w300),
+                      ),
+                    ),
+                  )
+                  : Padding(
+                    padding: const EdgeInsets.only(
+                      left: 16.0,
+                      top: 8,
+                      bottom: 8,
+                    ),
+                    child: Text(
+                      '${hymn.id}. ${hymn.title}',
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  );
+            },
+            openBuilder: (context, action) {
+              return Placeholder();
+              // return DetailsPage(hymn: hymn, isBookmark: isBookmarked);
+            },
+          );
+        },
+        separatorBuilder: (context, index) => const Divider(),
+      ),
+    );
+  }
+}

--- a/nah/lib/ui/hymnal/view_model/hymnal_provider.dart
+++ b/nah/lib/ui/hymnal/view_model/hymnal_provider.dart
@@ -2,14 +2,19 @@
 //The app should load the list of hymnals & display a list of hymns from the first hymnal
 
 import 'package:flutter/widgets.dart';
+import 'package:nah/data/db/database_helper.dart';
 import 'package:nah/data/models/hymnal_model.dart';
 import 'package:nah/data/repositories/hymnal_repository.dart';
 import 'package:nah/data/services/result.dart';
+import 'package:nah/domain/app_service.dart';
 
 class HymnalProvider extends ChangeNotifier {
   //call, using DI the get hymnals method from the hymnal repo
   final HymnalRepository _hymnalRepository;
-  HymnalProvider(this._hymnalRepository);
+
+  final AppService appService;
+
+  HymnalProvider(this.appService, this._hymnalRepository);
 
   //variable to hold the error message
   String? _errorMessage;
@@ -38,6 +43,7 @@ class HymnalProvider extends ChangeNotifier {
       case Success<List<Hymnal>> success:
         _hymnalList.clear();
         _hymnalList.addAll(success.data);
+        await appService.fetchAndCacheHymnsForAllHymnals(_hymnalList);
         _isLoading = false;
         _errorMessage = '';
         break;
@@ -55,7 +61,8 @@ class HymnalProvider extends ChangeNotifier {
   }
 
   @override
-  void dispose() {
+  void dispose() async {
+    await DatabaseHelper().close();
     super.dispose();
   }
 }

--- a/nah/lib/ui/hymnal/widgets/hymnal_screen.dart
+++ b/nah/lib/ui/hymnal/widgets/hymnal_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:nah/ui/core/ui/core_ui_export.dart';
+import 'package:nah/ui/core/ui/erro_message_with_retry.dart';
+import 'package:nah/ui/hymns/view_model/hymn_provider.dart';
 import 'package:provider/provider.dart';
 import '../view_model/hymnal_provider.dart';
 
@@ -26,13 +28,7 @@ class HymnalScreen extends StatelessWidget {
                   hymnalProvider.errorMessage!.isNotEmpty
               ? SliverFillRemaining(
                 hasScrollBody: false,
-                child: Center(
-                  child: Text(
-                    hymnalProvider.errorMessage!,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(fontSize: 16),
-                  ),
-                ),
+                child: ErroMessageWithRetry(),
               )
               : SliverList.separated(
                 itemCount: hymnalProvider.hymnals.length,
@@ -51,6 +47,9 @@ class HymnalScreen extends StatelessWidget {
                     subtitle: Text(hymnal.language),
                     onTap: () {
                       context.read<HymnalProvider>().selectHymnal(index);
+                      context.read<HymnProvider>().loadHymns(
+                        hymnal.language.toLowerCase(),
+                      );
                       Navigator.of(context).pop(hymnal);
                     },
                   );

--- a/nah/lib/ui/hymns/view_model/hymn_provider.dart
+++ b/nah/lib/ui/hymns/view_model/hymn_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:nah/data/models/hymn_model.dart';
+import 'package:nah/data/repositories/hymn_repository.dart';
+import 'package:nah/data/services/nah_services_export.dart';
+
+class HymnProvider with ChangeNotifier {
+  //variable to hold the hymn repo instance
+  final HymnRepository _hymnRepository;
+  HymnProvider(this._hymnRepository);
+
+  //variable to hold the loading state when hymns are being fetched
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  //variable to hold the error sms
+  String? _errorMessage;
+  String? get errorMessage => _errorMessage;
+
+  //varibale to hold the list of hymns
+  List<Hymn> _hymnList = [];
+  List<Hymn> get hymnList => List.unmodifiable(_hymnList);
+
+  //method to fetch hymns from repo
+  Future<void> loadHymns(String language) async {
+    //start loading
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+    final hymnFetchResult = await _hymnRepository.getHymns(
+      language.toLowerCase(),
+    );
+    switch (hymnFetchResult) {
+      case Success<List<Hymn>> success:
+        _hymnList.clear();
+        _hymnList.addAll(success.data);
+        _isLoading = false;
+        _errorMessage = '';
+        break;
+      case Failure<List<Hymn>> failure:
+        _isLoading = false;
+        _errorMessage = failure.error.toString();
+    }
+    notifyListeners();
+  }
+}

--- a/nah/test/data/repositories/hymn_repository_test.dart
+++ b/nah/test/data/repositories/hymn_repository_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
   group('Testing the hymn repository methods & functionality', () {
     //variable to hold language of hymns
-    final language = 'Chichewa';
+    final language = 'Chichewa'.toLowerCase();
     test('Test getting hymns from hymnservice with success', () async {
       //Arrange
       when(() => mockHymnService.fetchHymns(language)).thenAnswer(
@@ -27,7 +27,7 @@ void main() {
         ),
       );
       when(
-        () => mockDatabaseHelper.insertHymns(any()),
+        () => mockDatabaseHelper.insertHymns(language, any()),
       ).thenAnswer((_) async => Future.value());
 
       //Act
@@ -37,7 +37,9 @@ void main() {
       expect((result as Success<List<Hymn>>).data.first.title, 'Chichewa hymn');
 
       //verify that the database insert method is called upon returning a success from service
-      verify(() => mockDatabaseHelper.insertHymns(any())).called(1);
+      verify(
+        () => mockDatabaseHelper.insertHymns(language.toLowerCase(), any()),
+      ).called(1);
     });
 
     test(
@@ -47,7 +49,7 @@ void main() {
         when(
           () => mockHymnService.fetchHymns(language),
         ).thenAnswer((_) async => Failure(Exception('Error fetching hymns')));
-        when(() => mockDatabaseHelper.getHymns()).thenAnswer(
+        when(() => mockDatabaseHelper.getHymnsByLanguage(language)).thenAnswer(
           (_) async => [
             Hymn(
               id: 1,
@@ -67,7 +69,7 @@ void main() {
         //Assert
         expect(result, isA<Success<List<Hymn>>>());
         verify(() => mockHymnService.fetchHymns(language)).called(1);
-        verify(() => mockDatabaseHelper.getHymns()).called(1);
+        verify(() => mockDatabaseHelper.getHymnsByLanguage(language)).called(1);
       },
     );
 
@@ -78,7 +80,9 @@ void main() {
         when(
           () => mockHymnService.fetchHymns(language),
         ).thenAnswer((_) async => Failure(Exception('Error fetching hymns')));
-        when(() => mockDatabaseHelper.getHymns()).thenAnswer((_) async => []);
+        when(
+          () => mockDatabaseHelper.getHymnsByLanguage(language),
+        ).thenAnswer((_) async => []);
 
         //ACT
         final result = await hymnRepository.getHymns(language);
@@ -86,7 +90,7 @@ void main() {
         //Assert
         expect(result, isA<Failure>());
         verify(() => mockHymnService.fetchHymns(language)).called(1);
-        verify(() => mockDatabaseHelper.getHymns()).called(1);
+        verify(() => mockDatabaseHelper.getHymnsByLanguage(language)).called(1);
       },
     );
   });


### PR DESCRIPTION
- Edited the hymn table & added the language field,, so that each hymn should have a language field.
- Added the app service to iterate through the hymnals & cache their respective hymns
- Added a error handling  & retry mechanism
- Added the hymn screen & provider

## I M P O R T A N T
**B U G ! ! ! !**
when hymns are cached, the  hymns in one hymnal replace hymns of the other hymnal if they have the same id. shown when network turned off in NEH, the chichewa hymnal starts from 3