### PR TITLE
changes made to databasehelper  &  hymn screen

### DIFF
--- a/nah/lib/data/db/database_helper.dart
+++ b/nah/lib/data/db/database_helper.dart
@@ -38,29 +38,31 @@ class DatabaseHelper {
   Future<void> _createDB(Database db, int version) async {
     //create hymns table
     //each hymn row will have a language field for querying, A one (hymnal) to many (hymns) relationship
+    //each row will be uniquely identified by its id & language
     await db.execute('''
       CREATE TABLE $hymnTableName (
         $idField $idType,
         $languageField $textType,
         $titleField $textType,
         $odField $textTypeNullable,
-        $lyricsField $textType
+        $lyricsField $textType,
+        PRIMARY KEY ($idField, $languageField) -- Composite primary key
       )
     ''');
 
     //create hymnals table
     await db.execute('''
       CREATE TABLE $hymnalTableName (
-        $idField $idType,
+        $idField $idPrimaryKey,
         $titleField $textType,
         $languageField $textType
       )
     ''');
 
     //The method below will create a copy of the languageField. When the gethymns method searchs the where arguments and locates
-    //the row with the language, it will quickly refer to that row
+    //the row with the language & id, it will quickly refer to that row
     await db.execute(
-      'CREATE INDEX idx_hymns_language ON $hymnTableName ($languageField)',
+      'CREATE INDEX idx_hymns_language_id ON $hymnTableName ($languageField, $idField)',
     );
   }
 

--- a/nah/lib/data/db/db_parameters.dart
+++ b/nah/lib/data/db/db_parameters.dart
@@ -10,7 +10,9 @@ const String languageField = "language";
 const List<String> hymnColumns = [idField, titleField, odField, lyricsField];
 const List<String> hymnalColumns = [idField, titleField, languageField];
 
-const String idType = "INTEGER PRIMARY KEY";
+const String idType = "INTEGER";
+const String idPrimaryKey = "INTEGER PRIMARY KEY";
 const String idTypeAutoIncre = "INTEGER PRIMARY KEY AUTOINCREMENT";
+const String textPrimaryKey = "TEXT PRIMARY KEY NOT NULL";
 const String textType = "TEXT NOT NULL";
 const String textTypeNullable = "TEXT";

--- a/nah/lib/ui/core/ui/sliver_hymn_list.dart
+++ b/nah/lib/ui/core/ui/sliver_hymn_list.dart
@@ -61,7 +61,6 @@ class SliverHymnList extends StatelessWidget {
             },
             openBuilder: (context, action) {
               return Placeholder();
-              // return DetailsPage(hymn: hymn, isBookmark: isBookmarked);
             },
           );
         },

--- a/nah/lib/ui/hymns/view_model/hymn_provider.dart
+++ b/nah/lib/ui/hymns/view_model/hymn_provider.dart
@@ -17,7 +17,7 @@ class HymnProvider with ChangeNotifier {
   String? get errorMessage => _errorMessage;
 
   //varibale to hold the list of hymns
-  List<Hymn> _hymnList = [];
+  final List<Hymn> _hymnList = [];
   List<Hymn> get hymnList => List.unmodifiable(_hymnList);
 
   //method to fetch hymns from repo

--- a/nah/lib/ui/hymns/widgets/hymn_screen.dart
+++ b/nah/lib/ui/hymns/widgets/hymn_screen.dart
@@ -22,6 +22,7 @@ class _HymnScreenState extends State<HymnScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await context.read<HymnalProvider>().loadHymnals();
 
+      //If the widget is mounted in the widget tree, run the following callbacks
       if (!mounted) return;
       // After hymnals are loaded, load hymns for the selected hymnal
       final hymnalProvider = context.read<HymnalProvider>();
@@ -66,13 +67,14 @@ class _HymnScreenState extends State<HymnScreen> {
               );
             }),
           ),
-          hymnProvider.isLoading
+          //Since all is dependent on the hymnal provider, show the progress indicator if hymnals or hymns are loading
+          hymnalProvider.isLoading || hymnProvider.isLoading
               ? SliverFillRemaining(
                 hasScrollBody: false,
                 child: Center(child: CircularProgressIndicator()),
               )
-              : hymnProvider.errorMessage != null &&
-                  hymnProvider.errorMessage!.isNotEmpty
+              : hymnalProvider.errorMessage != null &&
+                  hymnalProvider.errorMessage!.isNotEmpty
               ? SliverFillRemaining(
                 hasScrollBody: false,
                 child: ErroMessageWithRetry(),


### PR DESCRIPTION
## Database Helper
- Fixed the bug where the hymns fetched would replace others when cached if they had the same id Now, hymns will be unique determined by the creation of the composite key in the CREATE TABLE hymns ( //other code
PRIMARY KEY ($idField, $languageField)

## Hymn Screen
- Added the functionality that when hymnals are being loaded in the initstate method, a circular progressive bar is indicated, not as hymnprovider isLoading but hymnalProvider isLoading